### PR TITLE
Remove sensitive properties files and apply .gitignore

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=project_backend


### PR DESCRIPTION
- 민감 정보가 포함된 `application.properties` 파일을 Git에서 제거했습니다.
- `.gitignore`에 등록하여 이후 커밋에서도 추적되지 않도록 설정했습니다.
- 해당 파일은 로컬에는 그대로 존재하므로 실행에는 문제 없습니다.
- main 브랜치에 병합해도 안전합니다.
