### PR TITLE
[수정]리뷰 도메인 파일 분리 및 리뷰 기능 모듈 정리

### DIFF
--- a/backend/src/main/java/pack/controller/review/LikeRequest.java
+++ b/backend/src/main/java/pack/controller/review/LikeRequest.java
@@ -1,0 +1,10 @@
+package pack.controller.review;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LikeRequest {
+    private String memberId;
+}

--- a/backend/src/main/java/pack/controller/review/ReviewController.java
+++ b/backend/src/main/java/pack/controller/review/ReviewController.java
@@ -1,0 +1,92 @@
+package pack.controller.review;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+//import pack.review.dto.ReviewReportRequest;
+import pack.dto.review.LikeResponse;
+//import pack.review.service.ReviewService;
+import pack.dto.review.ReviewRequest;
+import pack.dto.review.ReviewResponse;
+import pack.dto.review.ReviewUpdateRequest;
+import pack.service.review.ReviewService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/reviews")
+@RequiredArgsConstructor
+@Slf4j
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    // 리뷰 작성 (요청에서 memberId 직접 받아옴)
+    @PostMapping
+    public ResponseEntity<ReviewResponse> createReview(@RequestBody ReviewRequest request) {
+        return ResponseEntity.ok(reviewService.createReview(request));
+    }
+
+    // 리뷰 조회 (contentId 기준 + 정렬 옵션)
+    @GetMapping
+    public ResponseEntity<List<ReviewResponse>> getReviews(
+            @RequestParam Integer contentId,
+            @RequestParam(required = false, defaultValue = "LATEST") String sortType,
+            @RequestParam(required = false) String memberId // 로그인된 사용자 ID
+    ) {
+        return ResponseEntity.ok(reviewService.getReviewsByContentId(contentId, sortType, memberId));
+    }
+
+    // 리뷰 수정 (요청 바디에 memberId 포함 필요)
+    @PatchMapping("/{id}")
+    public ResponseEntity<ReviewResponse> updateReview(
+            @PathVariable("id") Integer id,
+            @RequestBody ReviewUpdateRequest request
+    ) {
+        request.setReviewId(id);
+        return ResponseEntity.ok(reviewService.updateReview(request, request.getMemberId()));
+    }
+
+    // 리뷰 삭제 (요청 파라미터로 memberId 전달)
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteReview(@PathVariable Integer id) {
+        reviewService.deleteReview(id);  // memberId 파라미터 제거
+        return ResponseEntity.ok("리뷰 삭제 완료");
+    }
+
+    // 리뷰의 댓글 작성
+    @PostMapping("{parentId}/comments")
+    public ResponseEntity<ReviewResponse> createComment(
+            @PathVariable Integer parentId,
+            @RequestBody ReviewRequest request
+    ) {
+        return ResponseEntity.ok(reviewService.createComment(parentId, request));
+    }
+
+    // 리뷰의 댓글 수정
+    @PatchMapping("/{id}/comments")
+    public ResponseEntity<ReviewResponse> updateComment(
+            @PathVariable("id") Integer id,
+            @RequestBody ReviewUpdateRequest request
+    ) {
+        request.setReviewId(id);
+        return ResponseEntity.ok(reviewService.updateComment(request, request.getMemberId()));
+    }
+
+    // 리뷰의 댓글 삭제
+    @DeleteMapping("/{id}/comments")
+    public ResponseEntity<String> deleteComment(@PathVariable Integer id) {
+        reviewService.deleteComment(id);
+        return ResponseEntity.ok("댓글 삭제 완료");
+    }
+
+    @PostMapping("/{id}/like")
+    public ResponseEntity<LikeResponse> toggleLike(
+            @PathVariable("id") Integer id,
+            @RequestBody LikeRequest request) {
+
+        return ResponseEntity.ok(reviewService.toggleLike(id, request.getMemberId()));
+    }
+
+}

--- a/backend/src/main/java/pack/dto/review/LikeResponse.java
+++ b/backend/src/main/java/pack/dto/review/LikeResponse.java
@@ -1,0 +1,11 @@
+package pack.dto.review;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class LikeResponse {
+    private boolean isLiked;
+    private int likeCount;
+}

--- a/backend/src/main/java/pack/dto/review/ReviewRequest.java
+++ b/backend/src/main/java/pack/dto/review/ReviewRequest.java
@@ -1,0 +1,16 @@
+package pack.dto.review;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewRequest {
+    private Integer contentId;
+    private String memberId;
+    private String cont;
+    private Integer rating;
+    private Boolean isSpoiler;
+}

--- a/backend/src/main/java/pack/dto/review/ReviewResponse.java
+++ b/backend/src/main/java/pack/dto/review/ReviewResponse.java
@@ -1,0 +1,23 @@
+package pack.dto.review;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class ReviewResponse {
+    private Integer reviewId;
+    private Integer gnum;
+    private String memberId;
+    private Integer contentId;
+    private String cont;
+    private Integer rating;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Integer likeCount;
+    private Boolean isSpoiler;
+    private Boolean isEdited; // (수정됨) 표시용
+    private Boolean isLiked;
+}

--- a/backend/src/main/java/pack/dto/review/ReviewUpdateRequest.java
+++ b/backend/src/main/java/pack/dto/review/ReviewUpdateRequest.java
@@ -1,0 +1,18 @@
+package pack.dto.review;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewUpdateRequest {
+    private Integer reviewId;
+    private String cont;
+    private Integer rating;
+    private Boolean isSpoiler;
+    private String memberId;
+}

--- a/backend/src/main/java/pack/entity/review/Review.java
+++ b/backend/src/main/java/pack/entity/review/Review.java
@@ -1,0 +1,46 @@
+package pack.entity.review;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "review")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Review {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id")
+    private Integer reviewId;
+
+    private Integer contentId;
+    private String memberId;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @Column(name = "gnum")
+    private Integer gnum;
+    private Integer rating;
+
+    private String cont;
+
+    @Column(name = "is_spoiler")
+    private Boolean isSpoiler;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/pack/entity/review/ReviewLike.java
+++ b/backend/src/main/java/pack/entity/review/ReviewLike.java
@@ -1,0 +1,29 @@
+package pack.entity.review;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Setter
+@Getter
+@Table(name = "review_likes")
+@IdClass(ReviewLikeId.class)  // 복합키 클래스 명시
+public class ReviewLike {
+    @Id
+    @Column(name = "member_id")
+    private String memberId;
+
+    @Id
+    @Column(name = "review_id")
+    private Integer reviewId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id", insertable = false, updatable = false)
+    private Review review;
+
+    @Column(name = "liked_at")
+    private LocalDateTime likeAt = LocalDateTime.now();
+}

--- a/backend/src/main/java/pack/entity/review/ReviewLikeId.java
+++ b/backend/src/main/java/pack/entity/review/ReviewLikeId.java
@@ -1,0 +1,30 @@
+package pack.entity.review;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class ReviewLikeId implements Serializable {
+    private String memberId;
+    private Integer reviewId;
+
+    // 기본 생성자, equals, hashCode 필수
+    public ReviewLikeId() {}
+
+    public ReviewLikeId(String memberId, Integer reviewId) {
+        this.memberId = memberId;
+        this.reviewId = reviewId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)  return true;
+        if (!(o instanceof ReviewLikeId)) return false;
+        ReviewLikeId that = (ReviewLikeId) o;
+        return Objects.equals(memberId, that.memberId) && Objects.equals(reviewId, that.reviewId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(memberId, reviewId);
+    }
+}

--- a/backend/src/main/java/pack/repository/review/ReviewLikeRepository.java
+++ b/backend/src/main/java/pack/repository/review/ReviewLikeRepository.java
@@ -1,0 +1,11 @@
+package pack.repository.review;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import pack.entity.review.ReviewLike;
+import pack.entity.review.ReviewLikeId;
+
+public interface ReviewLikeRepository extends JpaRepository<ReviewLike, ReviewLikeId> {
+    boolean existsByMemberIdAndReviewId(String memberId, Integer reviewId);
+    void deleteByMemberIdAndReviewId(String memberId, Integer reviewId);
+    int countByReviewId(Integer reviewId);
+}

--- a/backend/src/main/java/pack/repository/review/ReviewRepository.java
+++ b/backend/src/main/java/pack/repository/review/ReviewRepository.java
@@ -1,0 +1,34 @@
+package pack.repository.review;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import pack.entity.review.Review;
+
+import java.util.List;
+
+public interface ReviewRepository extends JpaRepository<Review, Integer> {
+
+    // 평점 높은 순 (리뷰만 — 댓글 제외: reviewId == gnum인 것만)
+    @Query("SELECT r FROM Review r WHERE r.contentId = :contentId AND r.reviewId = r.gnum ORDER BY r.rating DESC")
+    List<Review> findTopLevelByContentIdOrderByRatingDesc(@Param("contentId") Integer contentId);
+
+    // 최신 순 (리뷰만 — 댓글 제외: reviewId == gnum)
+    @Query("SELECT r FROM Review r WHERE r.contentId = :contentId AND r.reviewId = r.gnum ORDER BY r.createdAt DESC")
+    List<Review> findTopLevelByContentIdOrderByCreatedAtDesc(@Param("contentId") Integer contentId);
+
+    // 전체 (리뷰 + 댓글), 댓글은 gnum 기준 정렬, createdAt으로 보조 정렬
+    @Query("SELECT r FROM Review r WHERE r.contentId = :contentId ORDER BY r.gnum ASC, r.createdAt ASC")
+    List<Review> findAllByContentIdSorted(@Param("contentId") Integer contentId);
+
+    // gnum 기준으로 전체 삭제 (리뷰와 해당 댓글들 한 번에 삭제)
+    void deleteByGnum(Integer gnum);
+
+    @Query("SELECT r FROM Review r WHERE r.gnum = :reviewId AND r.reviewId <> r.gnum")
+    List<Review> findByGnum(@Param("reviewId") Integer reviewId);
+
+    List<Review> findByContentIdOrderByCreatedAtDesc(Integer contentId);
+
+    List<Review> findByContentIdOrderByRatingDesc(Integer contentId);
+
+}

--- a/backend/src/main/java/pack/service/review/ReviewService.java
+++ b/backend/src/main/java/pack/service/review/ReviewService.java
@@ -1,0 +1,173 @@
+package pack.service.review;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import pack.dto.review.LikeResponse;
+import pack.dto.review.ReviewRequest;
+import pack.dto.review.ReviewResponse;
+import pack.dto.review.ReviewUpdateRequest;
+import pack.entity.review.Review;
+import pack.entity.review.ReviewLike;
+import pack.repository.review.ReviewLikeRepository;
+import pack.repository.review.ReviewRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final ReviewLikeRepository reviewLikeRepository;
+
+    @Transactional
+    public ReviewResponse createReview(ReviewRequest request) {
+        Review review = new Review();
+        review.setContentId(request.getContentId());
+        review.setMemberId(request.getMemberId());
+        review.setCont(request.getCont());
+        review.setRating(request.getRating());
+        review.setIsSpoiler(request.getIsSpoiler());
+
+        // 첫 저장
+        Review saved = reviewRepository.save(review);
+
+        // gnum 지정 후 업데이트
+        saved.setGnum(saved.getReviewId());
+
+        return toResponse(reviewRepository.save(saved), request.getMemberId());
+    }
+
+
+    public ReviewResponse updateReview(ReviewUpdateRequest request, String currentUserId) {
+        Review review = reviewRepository.findById(request.getReviewId())
+                .orElseThrow(() -> new RuntimeException("Review not found"));
+
+        review.setCont(request.getCont());
+        review.setRating(request.getRating());
+        review.setIsSpoiler(request.getIsSpoiler());
+        review.setUpdatedAt(LocalDateTime.now());
+
+        return toResponse(reviewRepository.save(review), currentUserId);
+    }
+
+    @Transactional
+    public void deleteReview(Integer reviewId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new RuntimeException("리뷰를 찾을 수 없습니다."));
+
+        reviewRepository.deleteByGnum(reviewId);
+    }
+
+    public List<ReviewResponse> getReviewsByContentId(Integer contentId, String sortType, String memberId) {
+        if (sortType == null || sortType.isBlank()) {
+            sortType = "LATEST";
+        }
+
+        List<Review> reviews;
+
+        switch (sortType.toUpperCase()) {
+            case "RATING":
+                // ✅ 전체 리뷰 + 댓글 포함 정렬
+                reviews = reviewRepository.findByContentIdOrderByRatingDesc(contentId);
+                break;
+            case "LATEST":
+            default:
+                reviews = reviewRepository.findByContentIdOrderByCreatedAtDesc(contentId);
+                break;
+        }
+
+        return reviews.stream()
+                .map(review -> toResponse(review, memberId))
+                .toList();
+    }
+
+
+    @Transactional
+    public ReviewResponse createComment(Integer parentId, ReviewRequest request) {
+        Review parentReview = reviewRepository.findById(parentId)
+                .orElseThrow(() -> new RuntimeException("부모 리뷰가 존재하지 않습니다."));
+
+        Review comment = new Review();
+        comment.setContentId(parentReview.getContentId());
+        comment.setMemberId(request.getMemberId());
+        comment.setCont(request.getCont());
+        comment.setRating(null);
+        comment.setIsSpoiler(false);
+        comment.setGnum(parentReview.getGnum() != null ? parentReview.getGnum() : parentReview.getReviewId());
+
+        Review saved = reviewRepository.save(comment);
+        return toResponse(saved, request.getMemberId());
+    }
+
+    public ReviewResponse updateComment(ReviewUpdateRequest request, String currentUserId) {
+        Review review = reviewRepository.findById(request.getReviewId())
+                .orElseThrow(() -> new RuntimeException("댓글이 존재하지 않습니다."));
+
+        review.setCont(request.getCont());
+        review.setUpdatedAt(LocalDateTime.now());
+        return toResponse(reviewRepository.save(review), currentUserId);
+    }
+
+    @Transactional
+    public void deleteComment(Integer commentId) {
+        Review comment = reviewRepository.findById(commentId)
+                .orElseThrow(() -> new RuntimeException("댓글이 존재하지 않습니다."));
+
+        // 댓글인지 확인
+        if (comment.getReviewId().equals(comment.getGnum())) {
+            throw new RuntimeException("이 ID는 댓글이 아닌 리뷰입니다.");
+        }
+
+        reviewRepository.deleteById(commentId);
+    }
+
+
+    public ReviewResponse toResponse(Review review, String memberId) {
+        ReviewResponse dto = new ReviewResponse();
+        dto.setReviewId(review.getReviewId());
+        dto.setContentId(review.getContentId());
+        dto.setMemberId(review.getMemberId());
+        dto.setCont(review.getCont());
+        dto.setGnum(review.getGnum());
+        dto.setRating(review.getRating());
+        dto.setCreatedAt(review.getCreatedAt());
+        dto.setUpdatedAt(review.getUpdatedAt());
+        dto.setIsSpoiler(review.getIsSpoiler());
+        dto.setIsEdited(!review.getCreatedAt().equals(review.getUpdatedAt()));
+
+
+        // 좋아요 관련
+        boolean liked = (memberId != null) && reviewLikeRepository.existsByMemberIdAndReviewId(memberId, review.getReviewId());
+        int likeCount = reviewLikeRepository.countByReviewId(review.getReviewId());
+        dto.setIsLiked(liked);
+        dto.setLikeCount(likeCount);
+
+        return dto;
+    }
+
+    @Transactional
+    public LikeResponse toggleLike(Integer reviewId, String memberId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new RuntimeException("리뷰가 존재하지 않음"));
+
+        boolean isLiked;
+
+        if (reviewLikeRepository.existsByMemberIdAndReviewId(memberId, reviewId)) {
+            reviewLikeRepository.deleteByMemberIdAndReviewId(memberId, reviewId);
+            isLiked = false;
+        } else {
+            ReviewLike like = new ReviewLike();
+            like.setMemberId(memberId);
+            like.setReviewId(reviewId);
+            like.setReview(review);
+            reviewLikeRepository.save(like);
+            isLiked = true;
+        }
+
+        int likeCount = reviewLikeRepository.countByReviewId(reviewId);
+        return new LikeResponse(isLiked, likeCount);
+    }
+}


### PR DESCRIPTION
- 리뷰 관련 도메인(controller, dto, entity, repository, service) 디렉토리 분리
  - 기존 pack.review.* → pack.[layer].review 구조로 리팩토링
  - 유지보수 편의성과 도메인 모듈 분리 기준 정립
  - 
- 리뷰 관련 기능 구현/추가
  - 리뷰 좋아요 토글 기능을 위한 `ReviewLike`, `ReviewLikeId`, `ReviewLikeRepository` 추가
  - 프론트에서 사용할 DTO 추가 (`LikeResponse`, `LikeRequest`)
  - Spoiler 여부, 수정 여부 등 프론트 전송용 필드 구성 완료
  - 리뷰 조회 시 좋아요 여부, 본인 여부 포함