### PR TITLE
회원 인증 Spring Security 세션 기반 로그인 적용

### DIFF
--- a/backend/src/main/java/pack/config/SecurityConfig.java
+++ b/backend/src/main/java/pack/config/SecurityConfig.java
@@ -1,0 +1,34 @@
+package pack.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/auth/login",
+                                "/api/auth/register",
+                                "/api/member/signup",
+                                "/api/member/email-check",
+                                "/api/member/nickname-check").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(form -> form.disable());
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/pack/dto/member/LoginRequest.java
+++ b/backend/src/main/java/pack/dto/member/LoginRequest.java
@@ -1,5 +1,6 @@
 package pack.dto.member;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,5 +12,6 @@ import lombok.Setter;
 @AllArgsConstructor
 public class LoginRequest {
 	private String memberId;
+	@JsonProperty("password")
 	private String pwd;
 }

--- a/backend/src/main/java/pack/dto/member/SignUpRequest.java
+++ b/backend/src/main/java/pack/dto/member/SignUpRequest.java
@@ -17,7 +17,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class SignUpRequest{
-	@JsonProperty("id")
+	@JsonProperty("memberId")
 	public String memberId;
 	@JsonProperty("password")
 	public String pwd;


### PR DESCRIPTION
- 기존 로그인/회원가입 기능에 Spring Security 연동
- BCrypt 기반 비밀번호 암호화 적용
- 로그인 시 SecurityContextHolder에 인증정보 저장
- 세션 기반 로그인 유지
- @AuthenticationPrincipal 사용 가능한 상태로 구성
- 기존 API (/api/auth/login, /logout 등) 정상 동작 유지